### PR TITLE
Draft payjoin integration

### DIFF
--- a/payjoin/docker-compose.yaml
+++ b/payjoin/docker-compose.yaml
@@ -1,0 +1,47 @@
+version: "3"
+
+services:
+  payjoin:
+    environment:
+      - "RUST_LOG=debug"
+      - "TRACING=1"
+      - "CYPHERNODE_URL=https://gatekeeper:${GATEKEEPER_PORT}"
+    image: dangould/payjoin-client:0.1.28
+    command: 18443 bitcoin p receive 69420 "https://localhost/pj"
+    # // port cookie receive amount endpoint
+    volumes:
+      - "$APP_SCRIPT_PATH/data:/payjoin/data"
+      - "$GATEKEEPER_DATAPATH/certs/cert.pem:/payjoin/cert.pem:ro"
+      - "$LOGS_DATAPATH:/payjoin/logs"
+    networks:
+      - cyphernodeappsnet
+      - payjoinnet
+    restart: always
+    labels:
+      - "traefik.enable=true"
+      - "traefik.docker.network=cyphernodeappsnet"
+      - "traefik.frontend.rule=PathPrefixStrip:/pj"
+      - "traefik.frontend.passHostHeader=true"
+      - "traefik.port=3000"
+    deploy:
+      labels:
+        - "traefik.enable=true"
+        - "traefik.docker.network=cyphernodeappsnet"
+        - "traefik.frontend.rule=PathPrefixStrip:/pj"
+        - "traefik.frontend.passHostHeader=true"
+        - "traefik.port=3000"
+      replicas: 1
+      placement:
+        constraints:
+          - node.labels.io.cyphernode == true
+      restart_policy:
+        delay: 1s
+      update_config:
+        parallelism: 1
+    logging:
+      driver: local
+networks:
+  cyphernodeappsnet:
+    external: true
+  payjoinnet:
+    external: true

--- a/payjoin/test.sh
+++ b/payjoin/test.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+timeout_feature() {
+  local interval=10
+  local totaltime=60
+  local testwhat=${1}
+  local returncode
+  local endtime=$(($(date +%s) + ${totaltime}))
+
+  while :
+  do
+    eval ${testwhat}
+    returncode=$?
+
+    # If no error or 2 minutes passed, we get out of this loop
+    ([ "${returncode}" -eq "0" ] || [ $(date +%s) -gt ${endtime} ]) && break
+
+    printf "\e[1;31mMaybe it's too early, I'll retry every ${interval} seconds for $((${totaltime} / 60)) minutes ($((${endtime} - $(date +%s))) seconds left).\e[1;0m\r\n"
+
+    sleep ${interval}
+  done
+
+  return ${returncode}
+}
+
+do_test() {
+  local rc
+  rc=$(curl -k -s -o /dev/null -w "%{http_code}" https://127.0.0.1:${TRAEFIK_HTTPS_PORT}/payjoin)
+  [ "${rc}" -ne "400" ] && return 400
+  return 0
+}
+
+export TRAEFIK_HTTPS_PORT
+
+timeout_feature do_test
+returncode=$?
+
+# return 0: tests cool
+# return 1: tests failed
+return $returncode


### PR DESCRIPTION
payjoin-client enables receiving payjoin at spending01.dat wallet. The payjoin endpoint is exposed at https://localhost/payjoin. The receiving invoice is printed to the payjoin-client container's logs.

This passes preliminary smoke tests.

Wallet name, rpc port and endpoint are hard-coded into the binary, and should be configured at runtime. New BIP21 invoices should be available on endpoint request, too.